### PR TITLE
colors + typography

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,9 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Raleway&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/App.css
+++ b/src/App.css
@@ -1,33 +1,50 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;700&family=Raleway:wght@400;700&display=swap');
+/* Colors */
 
-body {
-    font-family: 'Raleway', 'Open Sans', sans-serif;
+:root {
+    --color-dark-blue: #194260;
+    --color-light-blue: #5F7E96;
+    --color-white: #FFFFFF;
+    --color-light-gray: #F6F6F6;
+    --color-gray: #A9A9A9;
+    --color-dark-gray: #363636;
+    --color-black: #000000;
+
+}
+
+/* Typography */
+
+h1, h2, h3, h4 {
+    font-family: 'Raleway', sans-serif;
+    font-style: normal;
+    font-weight: 700;
+    color: var(--color-black)
 }
 
 h1 {
     font-size: 42px;
+    line-height: 49px;
 }
 
 h2 {
     font-size: 36px;
+    line-height: 38px;
 }
 
 h3 {
-    font-size: 28px;
+    font-size: 24px;
+    line-height: 28px;
 }
 
 h4 {
     font-size: 18px;
+    line-height: 21px;
 }
 
 p {
-    font-size: 14px;
-}
-
-.TravelerInfo {
     font-family: 'Open Sans', sans-serif;
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 19px;
+    color: var(--color-dark-gray)
 }
 
-.TravelerInfoUnselected {
-    text-align: center;
-}

--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -20,6 +20,6 @@
     text-align: right;
     border-radius: 20px;
     font-size: 12px;
-    background-color:#194260;
+    background-color: var(--color-dark-blue);
     color: #FDF7FA;
   }


### PR DESCRIPTION
Imported our chosen typography via Google Fonts

Now, we can use app colors across any CSS file using the format `var(--color-{desired_color})`

We also shouldn't have to do any text styling besides what's already set in App.css